### PR TITLE
Add GitHub App auth option for PR review bot

### DIFF
--- a/.github/actions/pr-review/action.yml
+++ b/.github/actions/pr-review/action.yml
@@ -33,8 +33,17 @@ inputs:
         description: LLM API key (required)
         required: true
     github-token:
-        description: GitHub token for API access (required)
-        required: true
+        description: GitHub token for API access (optional if using GitHub App credentials)
+        required: false
+        default: ''
+    github-app-id:
+        description: GitHub App ID (optional, used to mint an installation token)
+        required: false
+        default: ''
+    github-app-private-key:
+        description: GitHub App private key (PEM) (optional, used to mint an installation token)
+        required: false
+        default: ''
     lmnr-api-key:
         description: Laminar API key for observability (optional)
         required: false
@@ -80,18 +89,28 @@ runs:
           run: |
               uv pip install --system ./software-agent-sdk/openhands-sdk ./software-agent-sdk/openhands-tools lmnr
 
+        - name: Generate GitHub App installation token
+          id: github-app-token
+          if: ${{ inputs.github-app-id != '' && inputs.github-app-private-key != '' }}
+          uses: actions/create-github-app-token@v1
+          with:
+              app-id: ${{ inputs.github-app-id }}
+              private-key: ${{ inputs.github-app-private-key }}
+              owner: ${{ github.event.pull_request.base.repo.owner.login }}
+              repositories: ${{ github.event.pull_request.base.repo.name }}
+
         - name: Check required configuration
           shell: bash
           env:
               LLM_API_KEY: ${{ inputs.llm-api-key }}
-              GITHUB_TOKEN: ${{ inputs.github-token }}
+              GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token || inputs.github-token }}
           run: |
               if [ -z "$LLM_API_KEY" ]; then
                 echo "Error: llm-api-key is required."
                 exit 1
               fi
               if [ -z "$GITHUB_TOKEN" ]; then
-                echo "Error: github-token is required."
+                echo "Error: github-token is required (or provide github-app-id + github-app-private-key)."
                 exit 1
               fi
 
@@ -111,7 +130,7 @@ runs:
               LLM_BASE_URL: ${{ inputs.llm-base-url }}
               REVIEW_STYLE: ${{ inputs.review-style }}
               LLM_API_KEY: ${{ inputs.llm-api-key }}
-              GITHUB_TOKEN: ${{ inputs.github-token }}
+              GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token || inputs.github-token }}
               LMNR_PROJECT_API_KEY: ${{ inputs.lmnr-api-key }}
               PR_NUMBER: ${{ github.event.pull_request.number }}
               PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -7,7 +7,7 @@ on:
     #   1. A new PR is opened (non-draft), OR
     #   2. A draft PR is marked as ready for review, OR
     #   3. A maintainer adds the 'review-this' label, OR
-    #   4. A maintainer requests openhands-agent or all-hands-bot as a reviewer
+    #   4. A maintainer requests openhands-agent, openhands-reviewer, or all-hands-bot as a reviewer
     # Adding labels and requesting new reviewers requires write access. GitHub may also allow PR authors
     # to re-request review from a previous reviewer.
     # The PR code is explicitly checked out for review, but secrets are only accessible
@@ -26,13 +26,15 @@ jobs:
         #   1. A new non-draft PR is opened by a non-first-time contributor, OR
         #   2. A draft PR is converted to ready for review by a non-first-time contributor, OR
         #   3. 'review-this' label is added, OR
-        #   4. openhands-agent or all-hands-bot is requested as a reviewer
+        #   4. openhands-agent, openhands-reviewer, or all-hands-bot is requested as a reviewer
         # Note: FIRST_TIME_CONTRIBUTOR PRs require manual trigger via label/reviewer request
         if: |
             (github.event.action == 'opened' && github.event.pull_request.draft == false && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
             (github.event.action == 'ready_for_review' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
             github.event.label.name == 'review-this' ||
             github.event.requested_reviewer.login == 'openhands-agent' ||
+            github.event.requested_reviewer.login == 'openhands-reviewer' ||
+            github.event.requested_reviewer.login == 'openhands-reviewer[bot]' ||
             github.event.requested_reviewer.login == 'all-hands-bot'
         concurrency:
             group: pr-review-${{ github.event.pull_request.number }}
@@ -49,5 +51,10 @@ jobs:
                   # Use the PR's head commit SHA to test SDK changes on the SDK repo itself
                   sdk-version: ${{ github.event.pull_request.head.sha }}
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
+                  # Authentication options:
+                  # - Preferred: GitHub App installation token (created inside the composite action)
+                  # - Fallback: all-hands-bot PAT (existing behavior)
+                  github-app-id: ${{ secrets.OPENHANDS_REVIEWER_APP_ID }}
+                  github-app-private-key: ${{ secrets.OPENHANDS_REVIEWER_APP_PRIVATE_KEY }}
                   github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -54,7 +54,7 @@ jobs:
                   # Authentication options:
                   # - Preferred: GitHub App installation token (created inside the composite action)
                   # - Fallback: all-hands-bot PAT (existing behavior)
-                  github-app-id: ${{ secrets.OPENHANDS_REVIEWER_APP_ID }}
-                  github-app-private-key: ${{ secrets.OPENHANDS_REVIEWER_APP_PRIVATE_KEY }}
+                  github-app-id: ${{ secrets.OH_REVIEWER_APP_ID }}
+                  github-app-private-key: ${{ secrets.OH_REVIEWER_APP_PRIVATE_KEY }}
                   github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/examples/03_github_workflows/02_pr_review/workflow.yml
+++ b/examples/03_github_workflows/02_pr_review/workflow.yml
@@ -5,7 +5,7 @@
 #  1. Copy this file to .github/workflows/pr-review.yml in your repository
 #  2. Add LLM_API_KEY to repository secrets
 #  3. Add GitHub authentication (either):
-#     - OPENHANDS_REVIEWER_APP_ID + OPENHANDS_REVIEWER_APP_PRIVATE_KEY (GitHub App), OR
+#     - OH_REVIEWER_APP_ID + OH_REVIEWER_APP_PRIVATE_KEY (GitHub App), OR
 #     - OPENHANDS_REVIEWER_GITHUB_TOKEN (a PAT)
 #  4. Customize the inputs below as needed
 #  5. Commit this file to your repository
@@ -58,6 +58,6 @@ jobs:
                   # Authentication options:
                   # - Preferred: GitHub App installation token (created inside the composite action)
                   # - Fallback: a PAT with pull request write access
-                  github-app-id: ${{ secrets.OPENHANDS_REVIEWER_APP_ID }}
-                  github-app-private-key: ${{ secrets.OPENHANDS_REVIEWER_APP_PRIVATE_KEY }}
+                  github-app-id: ${{ secrets.OH_REVIEWER_APP_ID }}
+                  github-app-private-key: ${{ secrets.OH_REVIEWER_APP_PRIVATE_KEY }}
                   github-token: ${{ secrets.OPENHANDS_REVIEWER_GITHUB_TOKEN }}

--- a/examples/03_github_workflows/02_pr_review/workflow.yml
+++ b/examples/03_github_workflows/02_pr_review/workflow.yml
@@ -4,9 +4,14 @@
 # To set this up:
 #  1. Copy this file to .github/workflows/pr-review.yml in your repository
 #  2. Add LLM_API_KEY to repository secrets
-#  3. Add GitHub authentication (either):
-#     - OH_REVIEWER_APP_ID + OH_REVIEWER_APP_PRIVATE_KEY (GitHub App), OR
-#     - OPENHANDS_REVIEWER_GITHUB_TOKEN (a PAT)
+#  3. Add GitHub authentication (either). Both options need repo permissions:
+#     - Pull requests: Read & write
+#     - Issues: Read & write
+#     - Contents: Read-only
+#
+#     Authentication options:
+#     - GitHub App (recommended): OH_REVIEWER_APP_ID + OH_REVIEWER_APP_PRIVATE_KEY, OR
+#     - Personal Access Token (PAT): OPENHANDS_REVIEWER_GITHUB_TOKEN
 #  4. Customize the inputs below as needed
 #  5. Commit this file to your repository
 #  6. Trigger the review by either:

--- a/examples/03_github_workflows/02_pr_review/workflow.yml
+++ b/examples/03_github_workflows/02_pr_review/workflow.yml
@@ -4,9 +4,12 @@
 # To set this up:
 #  1. Copy this file to .github/workflows/pr-review.yml in your repository
 #  2. Add LLM_API_KEY to repository secrets
-#  3. Customize the inputs below as needed
-#  4. Commit this file to your repository
-#  5. Trigger the review by either:
+#  3. Add GitHub authentication (either):
+#     - OPENHANDS_REVIEWER_APP_ID + OPENHANDS_REVIEWER_APP_PRIVATE_KEY (GitHub App), OR
+#     - OPENHANDS_REVIEWER_GITHUB_TOKEN (a PAT)
+#  4. Customize the inputs below as needed
+#  5. Commit this file to your repository
+#  6. Trigger the review by either:
 #     - Adding the "review-this" label to any PR, OR
 #     - Requesting openhands-agent as a reviewer
 #
@@ -52,4 +55,9 @@ jobs:
                   sdk-version: main
                   # Secrets
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  # Authentication options:
+                  # - Preferred: GitHub App installation token (created inside the composite action)
+                  # - Fallback: a PAT with pull request write access
+                  github-app-id: ${{ secrets.OPENHANDS_REVIEWER_APP_ID }}
+                  github-app-private-key: ${{ secrets.OPENHANDS_REVIEWER_APP_PRIVATE_KEY }}
+                  github-token: ${{ secrets.OPENHANDS_REVIEWER_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the PR review GitHub Action/workflow to support GitHub App authentication (short-lived installation tokens) as an alternative to a bot-user PAT.

Key changes:
- Composite action: add github-app-id/private-key inputs and mint installation token via actions/create-github-app-token@v1
- Workflow: pass OPENHANDS_REVIEWER_APP_ID/OPENHANDS_REVIEWER_APP_PRIVATE_KEY (PAT fallback preserved)
- Example workflow: document the same auth options


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub App authentication support as an alternative to personal access tokens. Workflows now support dual authentication paths—provide either GitHub App credentials or a token for API access.

* **Documentation**
  * Updated workflow examples to reflect new authentication configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->