### PR TITLE
Workflow: use fork SDK repo and optional LLM base URL

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -44,10 +44,15 @@ jobs:
             - name: Run PR Review
               uses: enyst/agent-sdk/.github/actions/pr-review@main
               with:
-                  llm-model: litellm_proxy/claude-sonnet-4-5-20250929
-                  llm-base-url: https://llm-proxy.app.all-hands.dev
+                  # LLM configuration
+                  # - Set LLM_MODEL / LLM_BASE_URL as repo variables to override.
+                  # - If you are using a direct provider (Anthropic/OpenAI/etc.), you typically do NOT need LLM_BASE_URL.
+                  llm-model: ${{ vars.LLM_MODEL || 'anthropic/claude-sonnet-4-5-20250929' }}
+                  llm-base-url: ${{ vars.LLM_BASE_URL || '' }}
                   # Review style: roasted (other option: standard)
                   review-style: roasted
+                  # Ensure we run against this repository (e.g. enyst/agent-sdk when testing in the fork)
+                  sdk-repo: ${{ github.repository }}
                   # Use the PR's head commit SHA to test SDK changes on the SDK repo itself
                   sdk-version: ${{ github.event.pull_request.head.sha }}
                   llm-api-key: ${{ secrets.LLM_API_KEY }}


### PR DESCRIPTION
Fixes PR review workflow behavior when testing in a fork:

- Sets composite action input `sdk-repo` to `${{ github.repository }}` so it checks out the current repo (e.g. `enyst/agent-sdk`) instead of defaulting to upstream.
- Removes hardcoded LLM proxy base URL by default; `llm-model` / `llm-base-url` can be overridden via repo variables `LLM_MODEL` and `LLM_BASE_URL`.

This avoids accidentally sending requests to the OpenHands LLM proxy when you intend to use a direct provider API key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR review automation workflow to use repository variables for LLM configuration, enabling customization of model and base URL settings per repository instead of relying on fixed default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->