### PR TITLE
Revert 1bf557ed: fix path to agent_script.py

### DIFF
--- a/.github/actions/pr-review/action.yml
+++ b/.github/actions/pr-review/action.yml
@@ -140,7 +140,7 @@ runs:
               REPO_NAME: ${{ github.repository }}
           run: |
               cd pr-repo
-              uv run python ../agent-sdk/examples/03_github_workflows/02_pr_review/agent_script.py
+              uv run python ../software-agent-sdk/examples/03_github_workflows/02_pr_review/agent_script.py
 
         - name: Upload logs as artifact
           uses: actions/upload-artifact@v4


### PR DESCRIPTION
Reverts commit `1bf557ed` which changed the composite action to run `agent_script.py` from `../agent-sdk/...`.

The composite action checks out the SDK into `software-agent-sdk/`, so the correct path is:

`../software-agent-sdk/examples/03_github_workflows/02_pr_review/agent_script.py`
